### PR TITLE
enhancement: don't drop items in arena map. (#1990)

### DIFF
--- a/Intersect (Core)/Config/MapOptions.cs
+++ b/Intersect (Core)/Config/MapOptions.cs
@@ -21,6 +21,10 @@ namespace Intersect.Config
                 MovementDirections = mEnableDiagonalMovement ? 8 : 4;
             }
         }
+        /// <summary>
+        /// option to drop items on arena type maps
+        /// </summary>
+        public bool DisablePlayerDropsInArenaMaps { get; set; } = false;
 
         /// <summary>
         /// The style of the game's border.

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -2946,6 +2946,11 @@ namespace Intersect.Server.Entities
 
         protected virtual void DropItems(Entity killer, bool sendUpdate = true)
         {
+            if (this is Player && Options.Instance.MapOpts.DisablePlayerDropsInArenaMaps && Map.ZoneType == MapZone.Arena)
+            {
+                return;
+            }
+
             // Drop items
             foreach (var slot in Items)
             {


### PR DESCRIPTION
* enhancement: don't drop items in arena map.

I think many project owners use this type of map for some pvp system or battle in general, I'm sending this suggestion that will protect the player's item drops when dying on this type of map.

* added check if the option to drop items in the arena is activated

* add server-side option to drop items in the arena or not

* Update Entity.cs

---------