### PR TITLE
enhancement: optional target window (#2289)

### DIFF
--- a/Intersect (Core)/Config/CombatOptions.cs
+++ b/Intersect (Core)/Config/CombatOptions.cs
@@ -70,6 +70,11 @@
         public bool EnableTurnAroundWhileCasting = false;
 
         /// <summary>
+        /// If enabled, the target window will be shown to players whenever they target an entity
+        /// </summary>
+        public bool EnableTargetWindow = true;
+
+        /// <summary>
         /// If enabled, this makes it so a player casting a friendly spell on a hostile target instead casts the spell upon themselves
         /// </summary>
         public bool EnableAutoSelfCastFriendlySpellsWhenTargetingHostile { get; set; } = false;

--- a/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
@@ -394,7 +394,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
             {
                 if (EntityWindow.IsHidden)
                 {
-                    EntityWindow.Show();
+                    Show();
                 }
             }
 
@@ -402,7 +402,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
             {
                 if (EntityWindow.IsHidden)
                 {
-                    EntityWindow.Show();
+                    Show();
                 }
 
                 if (MyEntity.IsDisposed())
@@ -1047,6 +1047,11 @@ namespace Intersect.Client.Interface.Game.EntityPanel
 
         public void Show()
         {
+            if (!Options.Instance.CombatOpts.EnableTargetWindow && !_isPlayerBox)
+            {
+                return;
+            }
+
             EntityWindow.Show();
         }
 


### PR DESCRIPTION
Adds a server combat option that if enabled (default), the target window will be shown to players whenever they target an entity